### PR TITLE
Add preliminary setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,49 @@ BerlinLernStick
 A mobile and secure Learn- and Working-Environment for school and home.
 
 The project is funded by TSB Technologiestiftung Berlin www.tsb-berlin.de
+
+Howto
+-----
+
+Per Pinning festlegen, dass der Bankix-Kernel immer genutzt wird
+
+    vim /etc/apt/preferences
+
+    Package: linux-image* linux-headers*
+    Pin: origin www.heise.de
+    Pin-Priority: 1001
+
+Paketquelle von heise.de eintragen
+
+    echo "deb http://www.heise.de/ct/projekte/ctbankix precise main" > /etc/apt/sources.list.d/ctbankix
+
+Paketquellen aktualisieren (eine GPG-Warnung ist hier normal)
+
+    apt-get update
+
+Schlüssel für heise-Paketquellen holen und eintragen
+
+    apt-get install ctbankix-keyring
+
+Paketquellen aktualisieren
+
+    apt-get update
+
+*HACK:* Fehler mit grub-probe unter Ubuntu-Livesystemen reparieren
+
+    mv /usr/sbin/grub-probe /usr/sbin/grub-probe.orig
+    wget http://cdn.edoceo.com/bin/grub-probe.sh -O /usr/sbin/grub-probe
+    chmod +x /usr/sbin/grub-probe
+
+Bankix-Kernel installieren (Version ist herauszufinden über `grep ^Package: /var/lib/apt/lists/www.heise.de_*_Packages`)
+
+    apt-get install linux-image-3.5.???
+
+alten Kernel deinstallieren (Version ist herauszufinden über `dpkg -l | grep linux-image-`)
+
+    apt-get remove linux-image-3.2.???
+
+Kernelabhängigkeiten unterbinden
+
+    apt-get remove linux-image-generic-pae
+    apt-get remove linux-headers-generic-pae


### PR DESCRIPTION
We have a working prototype floating around for quite a while;  here are the instructions to reproduce the setup.

Kernel updates are handled by the upstream, heise.de.
